### PR TITLE
Default checkstyle configuration added.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,4 +104,18 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.17</version>
+				<configuration>
+					<configLocation>google_checks.xml</configLocation>
+				</configuration>
+			</plugin>
+		</plugins>
+	</reporting>
+
 </project>


### PR DESCRIPTION
Adding default checkstyle configuration.
**mvn checkstyle:check** will trigger it.
Need to bind checkstyle with mvn [build process](http://stackoverflow.com/questions/12180765/maven-check-style-as-a-part-of-the-build).
Also define custom checkstyle [configuration](https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/custom-property-expansion.html).
