### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/src/main/java/pk/com/habsoft/robosim/filters/histogram/HistogramFilterView.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/histogram/HistogramFilterView.java
@@ -696,7 +696,7 @@ public class HistogramFilterView extends RootView {
 		}
 
 		// Save Robot Commands
-		StringBuffer buff = new StringBuffer(commands.length);
+		StringBuilder buff = new StringBuilder(commands.length);
 		int i = 0;
 		for (; i < commands.length - 1; i++) {
 			buff.append(commands[i][0] + "," + commands[i][1] + ";");

--- a/src/main/java/pk/com/habsoft/robosim/filters/histogram/SimulationBuilder.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/histogram/SimulationBuilder.java
@@ -6,6 +6,7 @@ import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 import javax.swing.DefaultCellEditor;
@@ -316,7 +317,7 @@ class DataModel extends DefaultTableModel {
 	public static final int MOVE = 2;
 
 	protected SimulationBuilder m_parent;
-	protected Vector<RobotCommands> m_vector;
+	protected List<RobotCommands> m_vector;
 
 	public DataModel(SimulationBuilder parent) {
 		m_parent = parent;
@@ -324,7 +325,7 @@ class DataModel extends DefaultTableModel {
 	}
 
 	public void insertData(RobotCommands r) {
-		m_vector.addElement(new RobotCommands(r.getCount(), r.getSense(), r.getMove()));
+		m_vector.add(new RobotCommands(r.getCount(), r.getSense(), r.getMove()));
 	}
 
 	@Override
@@ -352,7 +353,7 @@ class DataModel extends DefaultTableModel {
 		if (nRow < 0 || nRow >= getRowCount()) {
 			return "";
 		}
-		RobotCommands row = m_vector.elementAt(nRow);
+		RobotCommands row = m_vector.get(nRow);
 		switch (nCol) {
 		case COUNT:
 			return row.getCount();
@@ -369,7 +370,7 @@ class DataModel extends DefaultTableModel {
 		if (nRow < 0 || nRow >= getRowCount()) {
 			return;
 		}
-		RobotCommands row = m_vector.elementAt(nRow);
+		RobotCommands row = m_vector.get(nRow);
 
 		switch (nCol) {
 		case COUNT:


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed
