### PR TITLE
Code quality fix - Primitives should not be boxed just for "String" conversion.

### DIFF
--- a/src/main/java/pk/com/habsoft/robosim/filters/histogram/HistogramFilterAdvView.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/histogram/HistogramFilterAdvView.java
@@ -221,7 +221,7 @@ public class HistogramFilterAdvView extends RootView {
 		pnlSouth.setBounds(xLoc + spacing, yLoc + spacing, 2 * width - spacing, height - spacing);
 		RobotSensorListener sensorListener = new RobotSensorListener();
 		for (int i = 0; i < MAX_NO_OF_COLORS; i++) {
-			btnSensors[i].setActionCommand("" + i);
+			btnSensors[i].setActionCommand(Integer.toString(i));
 			btnSensors[i].setBackground(sensors[i]);
 			btnSensors[i].addActionListener(sensorListener);
 			pnlSouth.add(btnSensors[i]);
@@ -435,14 +435,14 @@ public class HistogramFilterAdvView extends RootView {
 
 	public void saveProperties() {
 
-		prop.setProperty(CYCLIC_WORLD_TAG, "" + chkCyclic.isSelected());
+		prop.setProperty(CYCLIC_WORLD_TAG, Boolean.toString(chkCyclic.isSelected()));
 		prop.setProperty(MOTION_NOISE_TAG, spnMotionNoise.getValue().toString());
 		prop.setProperty(SENSOR_NOISE_TAG, spnSensorNoise.getValue().toString());
 
 		// save world
-		prop.setProperty(NO_OF_ROWS_TAG, "" + DEF_NO_OF_ROWS);
-		prop.setProperty(NO_OF_COLUMNS_TAG, "" + DEF_NO_OF_COLUMNS);
-		prop.setProperty(NO_OF_COLORS_TAG, "" + DEF_NO_OF_COLORS);
+		prop.setProperty(NO_OF_ROWS_TAG, Integer.toString(DEF_NO_OF_ROWS));
+		prop.setProperty(NO_OF_COLUMNS_TAG, Integer.toString(DEF_NO_OF_COLUMNS));
+		prop.setProperty(NO_OF_COLORS_TAG, Integer.toString(DEF_NO_OF_COLORS));
 
 		for (int i = 0; i < world.length; i++) {
 			String row = "";
@@ -450,7 +450,7 @@ public class HistogramFilterAdvView extends RootView {
 			for (; j < world[i].length - 1; j++) {
 				row += world[i][j] + ",";
 			}
-			row += "" + world[i][j];
+			row += Integer.toString(world[i][j]);
 			prop.setProperty(MAP_ROW_TAG + (i + 1), row);
 		}
 

--- a/src/main/java/pk/com/habsoft/robosim/filters/histogram/HistogramFilterView.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/histogram/HistogramFilterView.java
@@ -349,7 +349,7 @@ public class HistogramFilterView extends RootView {
 		pnlSouth.setBounds(xLoc + spacing, yLoc + spacing, 2 * width - spacing, height - spacing);
 		RobotSensorListener sensorListener = new RobotSensorListener();
 		for (int i = 0; i < MAX_NO_OF_COLORS; i++) {
-			btnSensors[i].setActionCommand("" + i);
+			btnSensors[i].setActionCommand(String.valueOf(i));
 			btnSensors[i].setBackground(sensors[i]);
 			btnSensors[i].addActionListener(sensorListener);
 			pnlSouth.add(btnSensors[i]);
@@ -676,14 +676,14 @@ public class HistogramFilterView extends RootView {
 
 	public void saveProperties() {
 
-		prop.setProperty(CYCLIC_WORLD_TAG, "" + chkCyclic.isSelected());
+		prop.setProperty(CYCLIC_WORLD_TAG, Boolean.toString(chkCyclic.isSelected()));
 		prop.setProperty(MOTION_NOISE_TAG, spnMotionNoise.getValue().toString());
 		prop.setProperty(SENSOR_NOISE_TAG, spnSensorNoise.getValue().toString());
 
 		// save world
-		prop.setProperty(NO_OF_ROWS_TAG, "" + DEF_NO_OF_ROWS);
-		prop.setProperty(NO_OF_COLUMNS_TAG, "" + DEF_NO_OF_COLUMNS);
-		prop.setProperty(NO_OF_COLORS_TAG, "" + DEF_NO_OF_COLORS);
+		prop.setProperty(NO_OF_ROWS_TAG, Integer.toString(DEF_NO_OF_ROWS));
+		prop.setProperty(NO_OF_COLUMNS_TAG, Integer.toString(DEF_NO_OF_COLUMNS));
+		prop.setProperty(NO_OF_COLORS_TAG, Integer.toString(DEF_NO_OF_COLORS));
 
 		for (int i = 0; i < world.length; i++) {
 			String row = "";
@@ -691,7 +691,7 @@ public class HistogramFilterView extends RootView {
 			for (; j < world[i].length - 1; j++) {
 				row += world[i][j] + ",";
 			}
-			row += "" + world[i][j];
+			row += Integer.toString(world[i][j]);
 			prop.setProperty(MAP_ROW_TAG + (i + 1), row);
 		}
 

--- a/src/main/java/pk/com/habsoft/robosim/filters/histogram/WorldBuilder.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/histogram/WorldBuilder.java
@@ -126,7 +126,7 @@ public class WorldBuilder extends JDialog implements ActionListener {
 				btnArray[i][j] = new JButton();
 				int newColor = newWorld[i][j] % totalColors;
 				btnArray[i][j].setBackground(colors[newColor]);
-				btnArray[i][j].setActionCommand("" + newColor);
+				btnArray[i][j].setActionCommand(Integer.toString(newColor));
 				btnArray[i][j].addActionListener(this);
 				// btnArray[i][j].setOpaque(true);
 				// btnArray[i][j].setBorderPainted(false);
@@ -160,7 +160,7 @@ public class WorldBuilder extends JDialog implements ActionListener {
 					if (o.equals(btnArray[i][j])) {
 						int newColor = Integer.parseInt(o.getActionCommand());
 						newColor = (newColor + 1) % totalColors;
-						o.setActionCommand("" + newColor);
+						o.setActionCommand(Integer.toString(newColor));
 						newWorld[i][j] = newColor;
 						o.setBackground(colors[newColor]);
 						worldChanged = true;

--- a/src/main/java/pk/com/habsoft/robosim/filters/particles/Robot.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/particles/Robot.java
@@ -309,7 +309,7 @@ public class Robot implements IRobot {
 				if (bearing < 0)
 					bearing += 360;
 				double diff = Math.abs(ort - bearing);
-				lm.setText(bearing + "");
+				lm.setText(Double.toString(bearing));
 				// if (ort > 180)
 				// bearing += 360;
 

--- a/src/main/java/pk/com/habsoft/robosim/filters/particles/views/ControlPanel.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/particles/views/ControlPanel.java
@@ -286,68 +286,68 @@ public class ControlPanel extends JPanel implements ActionListener, ChangeListen
 	@Override
 	public boolean loadProperties() {
 		try {
-			DEF_PARTICLES = Integer.parseInt(prop.getProperty(TAG_PARTICLES, "" + DEF_PARTICLES));
+			DEF_PARTICLES = Integer.parseInt(prop.getProperty(TAG_PARTICLES, Integer.toString(DEF_PARTICLES)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_PARTICLES);
 		}
 		try {
-			DEF_SENSE_NOISE = Double.parseDouble(prop.getProperty(TAG_SENSE_NOISE, "" + DEF_SENSE_NOISE));
+			DEF_SENSE_NOISE = Double.parseDouble(prop.getProperty(TAG_SENSE_NOISE, Double.toString(DEF_SENSE_NOISE)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_SENSE_NOISE);
 		}
 		try {
-			DEF_STEERING_NOISE = Integer.parseInt(prop.getProperty(TAG_STEERING_NOISE, "" + DEF_STEERING_NOISE));
+			DEF_STEERING_NOISE = Integer.parseInt(prop.getProperty(TAG_STEERING_NOISE, Integer.toString(DEF_STEERING_NOISE)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_STEERING_NOISE);
 		}
 		try {
-			DEF_FORWARD_NOISE = Double.parseDouble(prop.getProperty(TAG_FORWARD_NOISE, "" + DEF_FORWARD_NOISE));
+			DEF_FORWARD_NOISE = Double.parseDouble(prop.getProperty(TAG_FORWARD_NOISE, Double.toString(DEF_FORWARD_NOISE)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_FORWARD_NOISE);
 		}
 		try {
-			DEF_ROBOT_SIZE = Integer.parseInt(prop.getProperty(TAG_ROBOT_SIZE, "" + DEF_ROBOT_SIZE));
+			DEF_ROBOT_SIZE = Integer.parseInt(prop.getProperty(TAG_ROBOT_SIZE, Integer.toString(DEF_ROBOT_SIZE)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_ROBOT_SIZE);
 		}
 		try {
-			DEF_GHOST_SIZE = Integer.parseInt(prop.getProperty(TAG_GHOST_SIZE, "" + DEF_GHOST_SIZE));
+			DEF_GHOST_SIZE = Integer.parseInt(prop.getProperty(TAG_GHOST_SIZE, Integer.toString(DEF_GHOST_SIZE)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_GHOST_SIZE);
 		}
 		try {
-			DEF_PARTICLE_SIZE = Integer.parseInt(prop.getProperty(TAG_PARTICLE_SIZE, "" + DEF_PARTICLE_SIZE));
+			DEF_PARTICLE_SIZE = Integer.parseInt(prop.getProperty(TAG_PARTICLE_SIZE, Integer.toString(DEF_PARTICLE_SIZE)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_PARTICLE_SIZE);
 		}
 		try {
-			DEF_LANDMARK_SIZE = Integer.parseInt(prop.getProperty(TAG_LANDMARK_SIZE, "" + DEF_LANDMARK_SIZE));
+			DEF_LANDMARK_SIZE = Integer.parseInt(prop.getProperty(TAG_LANDMARK_SIZE, Integer.toString(DEF_LANDMARK_SIZE)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_LANDMARK_SIZE);
 		}
 
 		try {
-			DEF_MOTION_ANGLE = Integer.parseInt(prop.getProperty(TAG_MOTION_ANGLE, "" + DEF_MOTION_ANGLE));
+			DEF_MOTION_ANGLE = Integer.parseInt(prop.getProperty(TAG_MOTION_ANGLE, Integer.toString(DEF_MOTION_ANGLE)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_MOTION_ANGLE);
 		}
 		try {
-			DEF_MOTIONS_SPEED = Double.parseDouble(prop.getProperty(TAG_MOTIONS_SPEED, "" + DEF_MOTIONS_SPEED));
+			DEF_MOTIONS_SPEED = Double.parseDouble(prop.getProperty(TAG_MOTIONS_SPEED, Double.toString(DEF_MOTIONS_SPEED)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_MOTIONS_SPEED);
 		}
 		try {
-			DEF_NEW_PARTICLES_RATIO = Double.parseDouble(prop.getProperty(TAG_NEW_PARTICLES_RATIO, "" + DEF_NEW_PARTICLES_RATIO));
+			DEF_NEW_PARTICLES_RATIO = Double.parseDouble(prop.getProperty(TAG_NEW_PARTICLES_RATIO, Double.toString(DEF_NEW_PARTICLES_RATIO)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_NEW_PARTICLES_RATIO);
 		}
 		try {
-			DEF_UNSAMPLED_PARTICLES_RATIO = Double.parseDouble(prop.getProperty(TAG_UNSAMPLED_PARTICLES_RATIO, "" + DEF_UNSAMPLED_PARTICLES_RATIO));
+			DEF_UNSAMPLED_PARTICLES_RATIO = Double.parseDouble(prop.getProperty(TAG_UNSAMPLED_PARTICLES_RATIO, Double.toString(DEF_UNSAMPLED_PARTICLES_RATIO)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_UNSAMPLED_PARTICLES_RATIO);
 		}
 		try {
-			DEF_SIMULATION_SPEED = Integer.parseInt(prop.getProperty(TAG_SIMULATION_SPEED, "" + DEF_SIMULATION_SPEED));
+			DEF_SIMULATION_SPEED = Integer.parseInt(prop.getProperty(TAG_SIMULATION_SPEED, Integer.toString(DEF_SIMULATION_SPEED)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_SIMULATION_SPEED);
 		}
@@ -359,12 +359,12 @@ public class ControlPanel extends JPanel implements ActionListener, ChangeListen
 			log.error("Invalid value of tag " + TAG_BOUNDED_VISION);
 		}
 		try {
-			DEF_LASER_RANGE = Integer.parseInt(prop.getProperty(TAG_LASER_RANGE, "" + DEF_LASER_RANGE));
+			DEF_LASER_RANGE = Integer.parseInt(prop.getProperty(TAG_LASER_RANGE, Integer.toString(DEF_LASER_RANGE)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_LASER_RANGE);
 		}
 		try {
-			DEF_LASER_ANGLE = Integer.parseInt(prop.getProperty(TAG_LASER_ANGLE, "" + DEF_LASER_ANGLE));
+			DEF_LASER_ANGLE = Integer.parseInt(prop.getProperty(TAG_LASER_ANGLE, Integer.toString(DEF_LASER_ANGLE)));
 		} catch (NumberFormatException e) {
 			log.error("Invalid value of tag " + TAG_LASER_ANGLE);
 		}
@@ -376,23 +376,23 @@ public class ControlPanel extends JPanel implements ActionListener, ChangeListen
 	public void saveProperties() {
 
 		// Save these properties
-		prop.setProperty(TAG_PARTICLES, "" + DEF_PARTICLES);
-		prop.setProperty(TAG_SENSE_NOISE, "" + DEF_SENSE_NOISE);
-		prop.setProperty(TAG_STEERING_NOISE, "" + DEF_STEERING_NOISE);
-		prop.setProperty(TAG_FORWARD_NOISE, "" + DEF_FORWARD_NOISE);
-		prop.setProperty(TAG_ROBOT_SIZE, "" + DEF_ROBOT_SIZE);
-		prop.setProperty(TAG_GHOST_SIZE, "" + DEF_GHOST_SIZE);
-		prop.setProperty(TAG_PARTICLE_SIZE, "" + DEF_PARTICLE_SIZE);
-		prop.setProperty(TAG_LANDMARK_SIZE, "" + DEF_LANDMARK_SIZE);
+		prop.setProperty(TAG_PARTICLES, Integer.toString(DEF_PARTICLES));
+		prop.setProperty(TAG_SENSE_NOISE, "" + Double.toString(DEF_SENSE_NOISE));
+		prop.setProperty(TAG_STEERING_NOISE, Double.toString(DEF_STEERING_NOISE));
+		prop.setProperty(TAG_FORWARD_NOISE, Double.toString(DEF_FORWARD_NOISE));
+		prop.setProperty(TAG_ROBOT_SIZE, Integer.toString(DEF_ROBOT_SIZE));
+		prop.setProperty(TAG_GHOST_SIZE, Integer.toString(DEF_GHOST_SIZE));
+		prop.setProperty(TAG_PARTICLE_SIZE, Integer.toString(DEF_PARTICLE_SIZE));
+		prop.setProperty(TAG_LANDMARK_SIZE, Integer.toString(DEF_LANDMARK_SIZE));
 
-		prop.setProperty(TAG_MOTION_ANGLE, "" + DEF_MOTION_ANGLE);
-		prop.setProperty(TAG_MOTIONS_SPEED, "" + DEF_MOTIONS_SPEED);
-		prop.setProperty(TAG_NEW_PARTICLES_RATIO, "" + DEF_NEW_PARTICLES_RATIO);
-		prop.setProperty(TAG_UNSAMPLED_PARTICLES_RATIO, "" + DEF_UNSAMPLED_PARTICLES_RATIO);
-		prop.setProperty(TAG_SIMULATION_SPEED, "" + DEF_SIMULATION_SPEED);
-		prop.setProperty(TAG_LASER_RANGE, "" + DEF_LASER_RANGE);
-		prop.setProperty(TAG_LASER_ANGLE, "" + DEF_LASER_ANGLE);
-		prop.setProperty(TAG_BOUNDED_VISION, "" + DEF_BOUNDED_VISION);
+		prop.setProperty(TAG_MOTION_ANGLE, Integer.toString(DEF_MOTION_ANGLE));
+		prop.setProperty(TAG_MOTIONS_SPEED, Double.toString(DEF_MOTIONS_SPEED));
+		prop.setProperty(TAG_NEW_PARTICLES_RATIO, Double.toString(DEF_NEW_PARTICLES_RATIO));
+		prop.setProperty(TAG_UNSAMPLED_PARTICLES_RATIO, Double.toString(DEF_UNSAMPLED_PARTICLES_RATIO));
+		prop.setProperty(TAG_SIMULATION_SPEED, Integer.toString(DEF_SIMULATION_SPEED));
+		prop.setProperty(TAG_LASER_RANGE, Integer.toString(DEF_LASER_RANGE));
+		prop.setProperty(TAG_LASER_ANGLE, Integer.toString(DEF_LASER_ANGLE));
+        prop.setProperty(TAG_BOUNDED_VISION, Boolean.toString(DEF_BOUNDED_VISION));
 	}
 
 }

--- a/src/main/java/pk/com/habsoft/robosim/planning/common/AlgorithmPanel.java
+++ b/src/main/java/pk/com/habsoft/robosim/planning/common/AlgorithmPanel.java
@@ -280,19 +280,19 @@ public class AlgorithmPanel extends RPanel implements ActionListener, Properties
 	@Override
 	public void saveProperties() {
 		if (prop != null) {
-			prop.setProperty(LEFT_TURN_COST, "" + leftTurnCost);
-			prop.setProperty(RIGHT_TURN_COST, "" + rightTurnCost);
-			prop.setProperty(GO_STRAIGHT_COST, "" + goStraightCost);
+			prop.setProperty(LEFT_TURN_COST, Integer.toString(leftTurnCost));
+			prop.setProperty(RIGHT_TURN_COST, Integer.toString(rightTurnCost));
+			prop.setProperty(GO_STRAIGHT_COST, Integer.toString(goStraightCost));
 
-			prop.setProperty(USE_STOCHASTIC_MOTION, "" + cbStochasticMotion.isSelected());
-			prop.setProperty(P_SUCCESS, "" + successProb);
+			prop.setProperty(USE_STOCHASTIC_MOTION, Boolean.toString(cbStochasticMotion.isSelected()));
+			prop.setProperty(P_SUCCESS, Double.toString(successProb));
 
-			prop.setProperty(ALGORITHM, "" + algorithm);
-			prop.setProperty(USE_HEURISTICS, "" + cbUseHeuristic.isSelected());
-			prop.setProperty(SHOW_HEURISTICS, "" + cbShowHuristicVal.isSelected());
-			prop.setProperty(DIAGONAL_MOTION, "" + cbAllowDiagonalMotion.isSelected());
-			prop.setProperty(USE_ORIENTATION, "" + cbConsiderOrientation.isSelected());
-			prop.setProperty(HEURISTICS, "" + cmbHeuristics.getSelectedIndex());
+			prop.setProperty(ALGORITHM, Integer.toString(algorithm));
+			prop.setProperty(USE_HEURISTICS, Boolean.toString(cbUseHeuristic.isSelected()));
+			prop.setProperty(SHOW_HEURISTICS, Boolean.toString(cbShowHuristicVal.isSelected()));
+			prop.setProperty(DIAGONAL_MOTION, Boolean.toString(cbAllowDiagonalMotion.isSelected()));
+			prop.setProperty(USE_ORIENTATION, Boolean.toString(cbConsiderOrientation.isSelected()));
+			prop.setProperty(HEURISTICS, Integer.toString(cmbHeuristics.getSelectedIndex()));
 		} else {
 			System.out.println("Saving Null properties in Drawing Panel");
 		}

--- a/src/main/java/pk/com/habsoft/robosim/planning/common/StatisticsPanel.java
+++ b/src/main/java/pk/com/habsoft/robosim/planning/common/StatisticsPanel.java
@@ -61,13 +61,13 @@ public class StatisticsPanel extends RPanel implements AlgorithmListener {
 	@Override
 	public void algorithmUpdate(Algorithm algorithm) {
 		if (algorithm != null) {
-			lblExplored.setText(Util.padRight("" + algorithm.getExploredSize(), 20));
-			lblUnExplored.setText(Util.padRight("" + algorithm.getUnExploredSize(), 20));
-			lblBlocked.setText(Util.padRight("" + algorithm.getBlockedSize(), 20));
-			lblTotal.setText(Util.padRight("" + algorithm.getTotalSize(), 20));
-			lblPathSize.setText(Util.padRight("" + algorithm.getPathSize(), 20));
-			lblResult.setText(Util.padRight("" + algorithm.getResult(), 20));
-			lblInstances.setText(Util.padRight("" + algorithm.getTotalInstances(), 20));
+			lblExplored.setText(Util.padRight(Integer.toString(algorithm.getExploredSize()), 20));
+			lblUnExplored.setText(Util.padRight(Integer.toString(algorithm.getUnExploredSize()), 20));
+			lblBlocked.setText(Util.padRight(Integer.toString(algorithm.getBlockedSize()), 20));
+			lblTotal.setText(Util.padRight(Integer.toString(algorithm.getTotalSize()), 20));
+			lblPathSize.setText(Util.padRight(Integer.toString(algorithm.getPathSize()), 20));
+			lblResult.setText(Util.padRight(algorithm.getResult(), 20));
+			lblInstances.setText(Util.padRight(Integer.toString(algorithm.getTotalInstances()), 20));
 		} else {
 			lblExplored.setText("0");
 			lblUnExplored.setText("0");

--- a/src/main/java/pk/com/habsoft/robosim/planning/pathplanning/views/PathPlannerView.java
+++ b/src/main/java/pk/com/habsoft/robosim/planning/pathplanning/views/PathPlannerView.java
@@ -198,8 +198,8 @@ public class PathPlannerView extends RootView implements AlgorithmListener {
 
 		prop.clear();
 		// save world
-		prop.setProperty(NO_OF_ROWS_TAG, "" + DEF_NO_OF_ROWS);
-		prop.setProperty(NO_OF_COLUMNS_TAG, "" + DEF_NO_OF_COLUMNS);
+		prop.setProperty(NO_OF_ROWS_TAG, Integer.toString(DEF_NO_OF_ROWS));
+		prop.setProperty(NO_OF_COLUMNS_TAG, Integer.toString(DEF_NO_OF_COLUMNS));
 
 		for (int i = 0; i < world.getRows(); i++) {
 			String row = "";

--- a/src/main/java/pk/com/habsoft/robosim/planning/pathplanning/views/WorldBuilder.java
+++ b/src/main/java/pk/com/habsoft/robosim/planning/pathplanning/views/WorldBuilder.java
@@ -158,7 +158,7 @@ public class WorldBuilder extends JDialog implements ActionListener {
 			for (int j = 0; j < newGrid[i].length; j++) {
 				btnArray[i][j] = new JButton();
 				btnArray[i][j].setBackground(colors[newGrid[i][j]]);
-				btnArray[i][j].setActionCommand("" + newGrid[i][j]);
+				btnArray[i][j].setActionCommand(Integer.toString(newGrid[i][j]));
 				btnArray[i][j].addActionListener(this);
 
 				pnlNorth.add(btnArray[i][j]);

--- a/src/main/java/pk/com/habsoft/robosim/planning/pathsmoother/views/PathSmoothingView.java
+++ b/src/main/java/pk/com/habsoft/robosim/planning/pathsmoother/views/PathSmoothingView.java
@@ -116,8 +116,8 @@ public class PathSmoothingView extends RootView implements WorldListener {
 		prop.clear();
 		// save world
 
-		prop.setProperty(NO_OF_ROWS_TAG, "" + world.getRows());
-		prop.setProperty(NO_OF_COLUMNS_TAG, "" + world.getColumns());
+		prop.setProperty(NO_OF_ROWS_TAG, Integer.toString(world.getRows()));
+		prop.setProperty(NO_OF_COLUMNS_TAG, Integer.toString(world.getColumns()));
 
 		for (int i = 0; i < world.getRows(); i++) {
 			String row = "";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131- Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.

Faisal Hameed
