### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/pk/com/habsoft/robosim/filters/kalman/KalmanFilterGaussian.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/kalman/KalmanFilterGaussian.java
@@ -3,6 +3,10 @@ package pk.com.habsoft.robosim.filters.kalman;
 import pk.com.habsoft.robosim.utils.Util;
 
 public class KalmanFilterGaussian {
+    
+    private KalmanFilterGaussian() {
+        
+    }
 
 	/**
 	 * 

--- a/src/main/java/pk/com/habsoft/robosim/filters/kalman/KalmanFilterTest.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/kalman/KalmanFilterTest.java
@@ -3,6 +3,10 @@ package pk.com.habsoft.robosim.filters.kalman;
 //http://www.udacity-forums.com/cs373/questions/10153/what-are-all-those-matrices-for-the-kalman-filter-part-i-x-f-p-h-r-u
 
 public class KalmanFilterTest {
+    
+    private KalmanFilterTest() {
+        
+    }
 
 	public static void main(String[] args) {
 

--- a/src/main/java/pk/com/habsoft/robosim/planning/algos/GradientDescent.java
+++ b/src/main/java/pk/com/habsoft/robosim/planning/algos/GradientDescent.java
@@ -6,6 +6,10 @@ import java.util.List;
 import pk.com.habsoft.robosim.planning.internal.PathNode;
 
 public class GradientDescent {
+    
+    private GradientDescent() {
+        
+    }
 
 	public static void main(String[] args) {
 		List<PathNode> path = new ArrayList<PathNode>();

--- a/src/main/java/pk/com/habsoft/robosim/utils/ImageUtil.java
+++ b/src/main/java/pk/com/habsoft/robosim/utils/ImageUtil.java
@@ -12,6 +12,10 @@ import java.io.IOException;
 import javax.imageio.ImageIO;
 
 public class ImageUtil {
+    
+    private ImageUtil() {
+        
+    }
 
 	public static double[] loadImageData(String name) {
 		BufferedImage bi = null;

--- a/src/main/java/pk/com/habsoft/robosim/utils/PositionGeometryTools.java
+++ b/src/main/java/pk/com/habsoft/robosim/utils/PositionGeometryTools.java
@@ -31,6 +31,10 @@ import java.awt.*;
  */
 
 public class PositionGeometryTools {
+    
+    private PositionGeometryTools() {
+        
+    }
 
 	/**
 	 * Calculate the distance between two X and Y points assuming that their

--- a/src/main/java/pk/com/habsoft/robosim/utils/RobotLogger.java
+++ b/src/main/java/pk/com/habsoft/robosim/utils/RobotLogger.java
@@ -6,6 +6,11 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 
 public class RobotLogger {
+    
+    private RobotLogger() {
+        
+    }
+    
 	public static Logger getLogger(String name) {
 
 		// very simple configuration to print on console

--- a/src/main/java/pk/com/habsoft/robosim/utils/UIUtils.java
+++ b/src/main/java/pk/com/habsoft/robosim/utils/UIUtils.java
@@ -13,6 +13,10 @@ import javax.swing.SwingConstants;
 import javax.swing.border.EtchedBorder;
 
 public class UIUtils {
+    
+    private UIUtils() {
+        
+    }
 
 	public static Font labelFont = new Font("Comic", Font.BOLD, 16);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
