### PR TITLE
Code quality fix - Redundant casts should not be used.

### DIFF
--- a/src/main/java/pk/com/habsoft/robosim/filters/particles/ParticleSimulator.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/particles/ParticleSimulator.java
@@ -65,7 +65,7 @@ public class ParticleSimulator implements Runnable, Iterable<SimulationObject> {
 		// add particles
 		for (int i = 0; i < paricles; i++) {
 			try {
-				IRobot r = (IRobot) temp.clone();
+				IRobot r = temp.clone();
 				r.setNoise(sense_noise, steering_noise, forward_noise);
 				r.random();
 				objects.add(r);

--- a/src/main/java/pk/com/habsoft/robosim/filters/particles/World.java
+++ b/src/main/java/pk/com/habsoft/robosim/filters/particles/World.java
@@ -104,7 +104,7 @@ public class World {
 				BufferedWriter bw = new BufferedWriter(new FileWriter(new File(file)));
 				for (int i = 0; i < landmarks.size(); i++) {
 					LandMark p = landmarks.get(i);
-					bw.write((int) p.getX() + "," + (int) p.getY() + "\n");
+					bw.write(p.getX() + "," + p.getY() + "\n");
 				}
 				bw.flush();
 				bw.close();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1905 - Redundant casts should not be used
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1905

Please let me know if you have any questions.

Faisal Hameed
