### PR TITLE
Code quality fix - "equals(Object obj)" and "hashCode()" should be overridden in pairs.

### DIFF
--- a/src/main/java/pk/com/habsoft/robosim/planning/internal/PathNode.java
+++ b/src/main/java/pk/com/habsoft/robosim/planning/internal/PathNode.java
@@ -7,53 +7,65 @@ import pk.com.habsoft.robosim.utils.RoboMathUtils;
  * This contains minimum information required to represent path node.
  */
 public class PathNode implements Cloneable {
-	private double x;
-	private double y;
+    private double x;
+    private double y;
 
-	public PathNode(double x, double y) {
-		this.x = x;
-		this.y = y;
-	}
+    public PathNode(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
 
-	public PathNode(PathNode node) {
-		this.x = node.getX();
-		this.y = node.getY();
-	}
+    public PathNode(PathNode node) {
+        this.x = node.getX();
+        this.y = node.getY();
+    }
 
-	public double getX() {
-		return x;
-	}
+    public double getX() {
+        return x;
+    }
 
-	public void setX(double x) {
-		this.x = x;
-	}
+    public void setX(double x) {
+        this.x = x;
+    }
 
-	public double getY() {
-		return y;
-	}
+    public double getY() {
+        return y;
+    }
 
-	public void setY(double y) {
-		this.y = y;
-	}
+    public void setY(double y) {
+        this.y = y;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (obj == null)
-			return false;
-		PathNode that = (PathNode) obj;
-		if (this.getX() == that.getX() && this.getY() == that.getY())
-			return true;
-		return false;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits(x);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(y);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
 
-	@Override
-	public PathNode clone() throws CloneNotSupportedException {
-		return (PathNode) super.clone();
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        PathNode that = (PathNode) obj;
+        if (this.getX() == that.getX() && this.getY() == that.getY())
+            return true;
+        return false;
+    }
 
-	@Override
-	public String toString() {
-		return "Path [x=" + RoboMathUtils.round(x, 3) + ", y=" + RoboMathUtils.round(y, 3) + "]";
-	}
+    @Override
+    public PathNode clone() throws CloneNotSupportedException {
+        return (PathNode) super.clone();
+    }
+
+    @Override
+    public String toString() {
+        return "Path [x=" + RoboMathUtils.round(x, 3) + ", y=" + RoboMathUtils.round(y, 3) + "]";
+    }
 
 }

--- a/src/main/java/pk/com/habsoft/robosim/planning/internal/WorldNode.java
+++ b/src/main/java/pk/com/habsoft/robosim/planning/internal/WorldNode.java
@@ -97,8 +97,21 @@ public class WorldNode implements Comparable<WorldNode> {
 		WorldNode that = (WorldNode) obj;
 		return this.xLoc == that.xLoc && this.yLoc == that.yLoc;
 	}
+	
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + action;
+        result = prime * result + depth;
+        long temp;
+        temp = Double.doubleToLongBits(heuristic);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        result = prime * result + xLoc;
+        result = prime * result + yLoc;
+        return result;
+    }
 
-	@Override
+    @Override
 	public int compareTo(WorldNode that) {
 		int returnValue = 0;
 		// f = g + h


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1206- "equals(Object obj)" and "hashCode()" should be overridden in pairs
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1206

Please let me know if you have any questions.

Faisal Hameed
